### PR TITLE
BREAKING CHANGES:

### DIFF
--- a/adapter/websocket/connection_manager.go
+++ b/adapter/websocket/connection_manager.go
@@ -209,7 +209,9 @@ func (cm *ConnectionManager) reconnectWithBackoff() {
 		}
 
 		// Resubscribe to all previous subscriptions - critical for continuity
-		if err := cm.client.subscriptionManager.ResubscribeAll(); err != nil {
+		// keepCurrentReferenceIds=false: generate new IDs after reconnection
+		// targetReferenceIds=nil: resubscribe to all subscriptions
+		if err := cm.client.subscriptionManager.HandleSubscriptions(false, nil); err != nil {
 			cm.client.logger.Printf("Resubscription failed after reconnection: %v", err)
 			cm.handleConnectionClosed()
 			continue

--- a/adapter/websocket/message_parser.go
+++ b/adapter/websocket/message_parser.go
@@ -10,7 +10,7 @@ import (
 
 // parseMessage processes incoming Saxo WebSocket binary messages
 // Following exact legacy broker_websocket.go binary protocol parsing
-// 
+//
 // Saxo WebSocket Binary Protocol:
 // - Bytes 0-8: Message Identifier (uint64, little-endian)
 // - Bytes 8-10: Reserved
@@ -28,7 +28,7 @@ func parseMessage(message []byte) (*ParsedMessage, error) {
 	messid := binary.LittleEndian.Uint64(message[0:8])
 
 	// Byte index 8-10: Reserved (skip)
-	
+
 	// Byte index 10: Reference ID Size
 	srefid := int(message[10])
 
@@ -81,14 +81,6 @@ func (pm *ParsedMessage) IsControlMessage() bool {
 	return isControlMessage(pm.ReferenceID)
 }
 
-// ParseJSONPayload unmarshals the payload as JSON
-func (pm *ParsedMessage) ParseJSONPayload(v interface{}) error {
-	if pm.PayloadFormat != 0 {
-		return fmt.Errorf("unexpected payload format: %d (expected 0 for JSON)", pm.PayloadFormat)
-	}
-	return json.Unmarshal(pm.Payload, v)
-}
-
 // String provides a debug representation
 func (pm *ParsedMessage) String() string {
 	return fmt.Sprintf("Message{ID:%d, RefID:%s, Format:%d, PayloadSize:%d}",
@@ -109,7 +101,7 @@ func handleHeartbeat(payload []byte, ws *SaxoWebSocketClient) error {
 		if len(h.Heartbeats) <= i {
 			continue
 		}
-		
+
 		hb := h.Heartbeats[i]
 		switch hb.Reason {
 		case "NoNewData":

--- a/adapter/websocket/saxo_websocket.go
+++ b/adapter/websocket/saxo_websocket.go
@@ -786,8 +786,10 @@ func (ws *SaxoWebSocketClient) reconnectWebSocket() error {
 		return err
 	}
 
-	// Resubscribe to all previous subscriptions
-	if err := ws.subscriptionManager.ResubscribeAll(); err != nil {
+	// Resubscribe to all previous subscriptions with new context ID
+	// keepCurrentReferenceIds=false: generate new IDs after reconnection
+	// targetReferenceIds=nil: resubscribe to all subscriptions
+	if err := ws.subscriptionManager.HandleSubscriptions(false, nil); err != nil {
 		ws.logger.Printf("reconnectWebSocket: Failed to resubscribe: %v", err)
 		return err
 	}

--- a/adapter/websocket/testing_test.go
+++ b/adapter/websocket/testing_test.go
@@ -17,8 +17,3 @@ func TestMain(m *testing.M) {
 	// Cleanup
 	os.Exit(code)
 }
-
-// Helper function for test setup
-func setupTestEnvironment() {
-	// Common test setup following legacy patterns
-}

--- a/adapter/websocket/utils.go
+++ b/adapter/websocket/utils.go
@@ -14,24 +14,6 @@ func generateHumanReadableID(subscriptionType string) string {
 	return fmt.Sprintf("%s-%s", subscriptionType, timestamp)
 }
 
-// getSubscriptionTypeFromPath maps endpoint path to subscription type name
-// Following legacy broker_websocket.go pattern exactly
-func getSubscriptionTypeFromPath(endpointPath string) string {
-	switch endpointPath {
-	case "/trade/v1/infoprices/subscriptions":
-		return "prices"
-	case "/port/v1/orders/subscriptions":
-		return "orders"
-	case "/root/v1/sessions/events/subscriptions/active":
-		return "session"
-	case "/port/v1/balances/subscriptions":
-		return "balance"
-	default:
-		// Fallback to a generic name if unknown path
-		return "subscription"
-	}
-}
-
 // isControlMessage determines if a message is a control message from Saxo
 // Following legacy patterns for _heartbeat, _disconnect, _resetsubscriptions
 func isControlMessage(refID string) bool {


### PR DESCRIPTION
- ResubscribeAll() signature changed: now accepts (keepCurrentReferenceIds bool, targetReferenceIds []string)
- Removed resetAllSubscriptions(), resetSpecificSubscriptions(), and resetSubscription()

Major improvements:

Subscription Reset Refactoring:
- Consolidated 4 subscription reset functions into single ResubscribeAll() with parameters
- Created generateNewReferenceId() to preserve asset type prefixes (FxSpotprices, ContractFuturesprices, etc.) while replacing timestamp suffix

Streaming Data Handlers:
- Wired handleOrderUpdate() to parse and send to orderUpdateChan
- Wired handlePortfolioUpdate() to parse and send to portfolioUpdateChan
- Wired handleSessionEvent() to message routing (was stubbed, now functional)
- All handlers use non-blocking channel sends with graceful fallback

Code Quality & Architecture:
- Extracted endpoint constants: EndpointPrices, EndpointOrders, EndpointBalance, EndpointSessionEvents
- Store EndpointPath in Subscription struct as single source of truth
- Removed unnecessary getSubscriptionTypeFromPath() function
- Eliminated hardcoded switch statements for endpoint mapping
- Simplified subscription request building logic